### PR TITLE
Add Test Coverage Job to Action

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -35,3 +35,15 @@ jobs:
         with:
           arguments: build
           gradle-version: 8.3
+
+      - name: Generate JaCoCo badge
+        id: jacoco
+        uses: cicirello/jacoco-badge-generator@v2
+        with:
+          jacoco-csv-file: ./build/reports/jacoco/test/jacocoTestReport.csv
+
+
+      - name: Log coverage percentages to workflow output
+        run: |
+          echo "coverage = ${{ steps.jacoco.outputs.coverage }}"
+          echo "branches = ${{ steps.jacoco.outputs.branches }}"

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -8,6 +8,7 @@
 plugins {
     // Apply the java-library plugin for API and implementation separation.
     id 'java-library'
+    id 'jacoco'
 }
 
 repositories {
@@ -35,7 +36,25 @@ java {
     }
 }
 
+jacoco {
+    toolVersion = "0.8.9"
+    reportsDirectory = layout.buildDirectory.dir('jacocoReport')
+}
+
 tasks.named('test') {
     // Use JUnit Platform for unit tests.
     useJUnitPlatform()
+}
+
+test {
+    finalizedBy jacocoTestReport // report is always generated after tests run
+}
+
+jacocoTestReport {
+    dependsOn test // tests are required to run before generating the report
+    reports {
+        xml.required = false
+        csv.required = false
+        html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
+    }
 }


### PR DESCRIPTION
It is inspired by https://dev.to/justahmed99/configure-github-actions-unit-test-for-java-project-plus-code-coverage-with-jacoco-4076

We are going to merge it into develop to allow others to take advantage of using test coverage report along MR 